### PR TITLE
Update babelrc options to tranform jsx that shadow-cljs can use

### DIFF
--- a/babel/src/js/demo/.babelrc
+++ b/babel/src/js/demo/.babelrc
@@ -1,7 +1,9 @@
 {
     "presets": [
         ["env", {
-            "modules": false
+            "targets": {
+                "esmodules": true
+            }
         }]
     ],
     "plugins": [


### PR DESCRIPTION
I updated env options so that `npm run build` transforms js that shadow-cljs can use